### PR TITLE
Use the default time scale for Spine demo

### DIFF
--- a/Editors/FlxSpine/source/MenuState.hx
+++ b/Editors/FlxSpine/source/MenuState.hx
@@ -37,8 +37,6 @@ class MenuState extends FlxState
 		spineSprite = cast new SpineBoyTest(FlxSpine.readSkeletonData("spineboy", "assets"), 300, 420);
 		add(spineSprite);
 		
-		FlxG.timeScale = 0.66;
-		
 		var instructions = new FlxText(0, 0, 250, "Space: Toggle Debug Display\nMove: Arrows", 12);
 		add(instructions);
 	}


### PR DESCRIPTION
The animation seemed like is was in slow motion, and made it seem like it was not very performant. This change makes it animate at the same speed as in the Spine editor.
