### PR TITLE
Demonstrate MouseEventManager.remove

### DIFF
--- a/Input/MouseEventManager/source/Card.hx
+++ b/Input/MouseEventManager/source/Card.hx
@@ -91,4 +91,8 @@ class Card extends FlxNapeSprite
 		// Finish the card animation
 		FlxTween.tween(scale, { x: 1 }, TURNING_TIME / 2);
 	}
+	override public function destroy():Void {
+		MouseEventManager.remove(this);
+		super.destroy();
+	}
 }


### PR DESCRIPTION
Although it's not technically required for such a simple demo, the MouseEventManager should demonstrate proper cleanup of references. Bad things happen if you don't use MouseEventManager.remove(obj) before destroying objects.
