### PR TITLE
Update Player.hx

### DIFF
--- a/Platformers/Project Jumper/source/Player.hx
+++ b/Platformers/Project Jumper/source/Player.hx
@@ -218,6 +218,8 @@ class Player extends FlxSprite
 				velocity.y = - 0.6 * maxVelocity.y;
 			}
 		}
+		else
+			_jumpTime = -1.0;
 	}
 	
 	private function shoot():Void 


### PR DESCRIPTION
Fixes double-jump bug: Before you could do "infinite" mini double jumps by tapping the jump key before the apex is reached. Now you can only do JUMPS_ALLOWED double jumps (still works fine with dynamic jump).
