### PR TITLE
Fix the zoom of the ScaleModes demo

### DIFF
--- a/Flixel Features/ScaleModes/source/Main.hx
+++ b/Flixel Features/ScaleModes/source/Main.hx
@@ -13,7 +13,7 @@ class Main extends Sprite
 	var gameWidth:Int = 320; // Width of the game in pixels (might be less / more in actual pixels depending on your zoom).
 	var gameHeight:Int = 240; // Height of the game in pixels (might be less / more in actual pixels depending on your zoom).
 	var initialState:Class<FlxState> = PlayState; // The FlxState the game starts with.
-	var zoom:Float = -1; // If -1, zoom is automatically calculated to fit the window dimensions.
+	var zoom:Float = 2; // If -1, zoom is automatically calculated to fit the window dimensions.
 	var framerate:Int = 60; // How many frames per second the game should run at.
 	var skipSplash:Bool = false; // Whether to skip the flixel splash screen that appears in release mode.
 	var startFullscreen:Bool = false; // Whether to start the game in fullscreen on desktop targets


### PR DESCRIPTION
Fix it to 2 so it won't be calculated automatically. It can give problems if you open the swf with a browser.
