### PR TITLE
Fix for default Flixel override of HTML5 backend

### DIFF
--- a/Flixel Features/Colors/Project.xml
+++ b/Flixel Features/Colors/Project.xml
@@ -36,7 +36,6 @@
 	
 	<!--------------------------------LIBRARIES------------------------------------->
 	
-	<haxelib name="openfl" />
 	<haxelib name="flixel" />
 	
 	<!--In case you want to use the addons package-->


### PR DESCRIPTION
Since Flixel overrides the HTML5 target by default, this project file should not include OpenFL itself, allowing Flixel to determine how it wants to load OpenFL
