### PR TITLE
Modified TiledLevel.hx To support Multiple tilesets and collidable layers

### DIFF
--- a/Editors/TiledEditor/source/TiledLevel.hx
+++ b/Editors/TiledEditor/source/TiledLevel.hx
@@ -64,7 +64,7 @@ class TiledLevel extends TiledMap
 			var tilemap:FlxTilemap = new FlxTilemap();
 			tilemap.widthInTiles = width;
 			tilemap.heightInTiles = height;
-			tilemap.loadMap(tileLayer.tileArray, processedPath, tileSet.tileWidth, tileSet.tileHeight, OFF, 1, 1, 1);
+			tilemap.loadMap(tileLayer.tileArray, processedPath, tileSet.tileWidth, tileSet.tileHeight, OFF, tileSet.firstGID, 1, 1);
 			
 			if (tileLayer.properties.contains("nocollide"))
 			{
@@ -141,7 +141,10 @@ class TiledLevel extends TiledMap
 			{
 				// IMPORTANT: Always collide the map with objects, not the other way around. 
 				//			  This prevents odd collision errors (collision separation code off by 1 px).
-				return FlxG.overlap(map, obj, notifyCallback, processCallback != null ? processCallback : FlxObject.separate);
+				if(FlxG.overlap(map, obj, notifyCallback, processCallback != null ? processCallback : FlxObject.separate))
+				{
+					return true;
+				}
 			}
 		}
 		return false;

--- a/Input/GridMovement/source/TiledLevel.hx
+++ b/Input/GridMovement/source/TiledLevel.hx
@@ -62,7 +62,7 @@ class TiledLevel extends TiledMap
 			var tilemap:FlxTilemap = new FlxTilemap();
 			tilemap.widthInTiles = width;
 			tilemap.heightInTiles = height;
-			tilemap.loadMap(tileLayer.tileArray, processedPath, tileSet.tileWidth, tileSet.tileHeight, OFF, 1, 1, 1);
+			tilemap.loadMap(tileLayer.tileArray, processedPath, tileSet.tileWidth, tileSet.tileHeight, OFF, tileSet.firstGID, 1, 1);
 			
 			if (tileLayer.properties.contains("nocollide"))
 			{
@@ -119,7 +119,10 @@ class TiledLevel extends TiledMap
 			{
 				// IMPORTANT: Always collide the map with objects, not the other way around. 
 				//			  This prevents odd collision errors (collision separation code off by 1 px).
-				return FlxG.overlap(map, obj, notifyCallback, processCallback != null ? processCallback : FlxObject.separate);
+				if(FlxG.overlap(map, obj, notifyCallback, processCallback != null ? processCallback : FlxObject.separate))
+				{
+					return true;
+				}
 			}
 		}
 		return false;


### PR DESCRIPTION
Modified TiledLevel.hx to allow support for multiple tilesets per .tmx file. Changed a hardcoded '1' to the dynamic 'tileSet.firstGUID' value pulled from the tmx file.

Modified TiledLevel.hx to fix bug that only checked the first collidable
layer for collisions. Moved the 'FlxG.overlap' call to the condition of an if statement. If a collision occurs, it then returns true. If not, it continues the loop.
