### PR TITLE
Update for HaxeFlixel/flixel#1220

### DIFF
--- a/Flixel Features/FlxCamera/source/HUD.hx
+++ b/Flixel Features/FlxCamera/source/HUD.hx
@@ -1,8 +1,7 @@
 package;
 
-import flixel.FlxG;
-import flixel.group.FlxGroup;
 import flixel.FlxSprite;
+import flixel.group.FlxGroup;
 import flixel.text.FlxText;
 import flixel.util.FlxColor;
 

--- a/Flixel Features/FlxCamera/source/PlayState.hx
+++ b/Flixel Features/FlxCamera/source/PlayState.hx
@@ -1,24 +1,14 @@
 package;
 
-import flixel.addons.nape.FlxNapeSprite;
-import flixel.addons.nape.FlxNapeState;
-import flixel.util.FlxSpriteUtil;
-import haxe.EnumFlags;
-import haxe.EnumTools;
-import nape.Config;
-import nape.geom.Vec2;
-import nape.phys.Body;
-import nape.phys.BodyType;
-import nape.phys.Material;
-import nape.shape.Polygon;
-import flash.display.BitmapData;
 import flash.display.BlendMode;
 import flash.Lib;
+import flixel.addons.nape.FlxNapeState;
 import flixel.FlxCamera;
 import flixel.FlxG;
-import flixel.math.FlxPoint;
 import flixel.FlxSprite;
+import flixel.util.FlxSpriteUtil;
 import HUD;
+import nape.geom.Vec2;
 import openfl.Assets;
 
 /**


### PR DESCRIPTION
Hasn't been merged yet in flixel.  Made this for if it does get merged in its current status.

Camera lerp is now a value from 0 to 1, 1 being the new default.  Checked everywhere, and this is the only time `followLerp` or the 4th parameter of `FlxCamera.follow()` was used.
