### PR TITLE
Ensure that shaders can be compiled on Android

### DIFF
--- a/Effects/PostProcess/assets/shaders/grayscale.frag
+++ b/Effects/PostProcess/assets/shaders/grayscale.frag
@@ -1,5 +1,3 @@
-#version 120
-
 #ifdef GL_ES
     precision mediump float;
 #endif

--- a/Effects/PostProcess/assets/shaders/invert.frag
+++ b/Effects/PostProcess/assets/shaders/invert.frag
@@ -1,5 +1,3 @@
-#version 120
-
 #ifdef GL_ES
     precision mediump float;
 #endif

--- a/Effects/PostProcess/assets/shaders/scanline.frag
+++ b/Effects/PostProcess/assets/shaders/scanline.frag
@@ -1,5 +1,3 @@
-#version 120
-
 #ifdef GL_ES
     precision mediump float;
 #endif
@@ -8,7 +6,7 @@ varying vec2 vTexCoord;
 uniform vec2 uResolution;
 uniform sampler2D uImage0;
 
-uniform float scale = 1.0;
+const float scale = 1.0;
 
 void main()
 {


### PR DESCRIPTION
When compiling shaders on Android, I found the following two issues
1) Writing `#version 120` will fail with `GLSL error: #version must occur before any other statement in the program`
2) Attempting to initialize uniforms, e.g. `uniform float amount = 0.2;` - will fail with `'uniform' :  cannot initialize this type of qualifier`

The error will be similar to the following:

```
I/trace   (23534): Shader.hx:53: Fragment shader compilation failed.
I/trace   (23534): ERROR: 0:2: '' :     GLSL error: #version must occur before any other statement in the program
I/trace   (23534): ERROR: 0:11: 'uniform' :  cannot initialize this type of qualifier
I/trace   (23534): ERROR: 2 compilation errors.  No code generated.
```

So, in the postprocessing demo, the `grayscale` and `invert` fragment shaders will fail with the `#version 120` issue on Android and `scanline` will fail with both `#version 120` and `uniform float scale = 1.0;`. This PR fixes those issues.
## 

PS. 
- The `scanline` shader doesn't work properly on Android... 
- The `grain` shader, although _very_ pretty, absolutely kills the framerate on Android.
