### PR TITLE
FlxNape: got SolarSystem demo back in action

### DIFF
--- a/Flixel Features/FlxNape/source/Main.hx
+++ b/Flixel Features/FlxNape/source/Main.hx
@@ -18,6 +18,8 @@ class Main extends Sprite
 	var framerate:Int = 60; // How many frames per second the game should run at.
 	var skipSplash:Bool = false; // Whether to skip the flixel splash screen that appears in release mode.
 	var startFullscreen:Bool = false; // Whether to start the game in fullscreen on desktop targets
+
+	private static inline var statesNumber:Int = 6; // Number of states available in the demo
 	
 	// You can pretty much ignore everything from here on - your code should go in your states.
 	
@@ -73,14 +75,14 @@ class Main extends Sprite
 	public static function nextState()
 	{
 		currentState++;
-		currentState %= 5;
+		currentState %= statesNumber;
 		changeState();
 	}
 	
 	public static function prevState()
 	{
-		currentState--;
-		currentState < 0 ? currentState = 4 : null;
+		currentState += (statesNumber - 1);
+		currentState %= statesNumber;
 		changeState();
 	}
 	
@@ -93,6 +95,7 @@ class Main extends Sprite
 			case 2: FlxG.switchState(new Blob());
 			case 3: FlxG.switchState(new Fight());
 			case 4: FlxG.switchState(new Cutup());
+			case 5: FlxG.switchState(new SolarSystem());
 		}
 	}
 }

--- a/Flixel Features/FlxNape/source/states/SolarSystem.hx
+++ b/Flixel Features/FlxNape/source/states/SolarSystem.hx
@@ -1,6 +1,6 @@
 package states;
 import flixel.addons.nape.FlxNapeSprite;
-import flixel.addons.nape.FlxNapeState;
+import flixel.addons.nape.FlxNapeSpace;
 import nape.callbacks.CbEvent;
 import nape.callbacks.CbType;
 import nape.callbacks.InteractionCallback;
@@ -12,28 +12,35 @@ import flixel.FlxG;
 import flixel.math.FlxPoint;
 import flixel.math.FlxMath;
 import flixel.math.FlxAngle;
+import flixel.FlxState;
 
 /**
  * @author TiagoLr ( ~~~ProG4mr~~~ )
  */
-class SolarSystem extends FlxNapeState
+class SolarSystem extends BaseState
 {
 	private var shooter:Shooter;
 	private var planets:Array<FlxNapeSprite>;
-	private static var halfWidth:Int = Std.int(FlxG.width / 2);
-	private static var halfHeight:Int = Std.int(FlxG.height / 2);
+	private static var halfWidth:Int;
+	private static var halfHeight:Int;
 	private static var gravity:Int = Std.int(5e4);
+
 	private var sun:FlxNapeSprite;
 	
 	override public function create():Void 
 	{	
 		super.create();
+
+		halfWidth = Std.int(FlxG.width / 2);
+		halfHeight = Std.int(FlxG.height / 2);
+
+		FlxNapeSpace.init();
 		
 		FlxNapeSpace.space.worldAngularDrag = 0;
 		FlxNapeSpace.space.worldLinearDrag = 0;
 		FlxNapeSpace.space.gravity = new Vec2(0, 0);
 		
-		createWalls();
+		FlxNapeSpace.createWalls();
 		
 		createSolarSystem();
 		
@@ -85,11 +92,6 @@ class SolarSystem extends FlxNapeState
 	override public function update(elapsed:Float):Void 
 	{	
 		super.update(elapsed);
-		
-		if (FlxG.keys.justPressed.G)
-			napeDebugEnabled = false;
-		if (FlxG.keys.justPressed.R)
-			FlxG.resetState();
 			
 		for (planet in planets)
 		{
@@ -114,13 +116,6 @@ class SolarSystem extends FlxNapeState
 			
 		if (FlxG.keys.justPressed.D)
 			planets[0].body.applyImpulse(new Vec2(10, 0));
-			
-		
-		if (FlxG.keys.justPressed.LEFT)
-			FlxPhysicsDemo.prevState();
-		if (FlxG.keys.justPressed.RIGHT)
-			FlxPhysicsDemo.nextState();
-		
 		
 	}
 	


### PR DESCRIPTION
### `FlxNape`

Minor changes to get `SolarSystem` demo back.
- Number of states in demo extracted into a constant `statesNumber` for convenient changes in the future
- Prettier `prevDemo` function in `Main` and overall refactoring to use `statesNumber`
- Some changes in `SolarSystem` class to make it work with the new structure
  - inheritance from `FlxNapeState` changed to `BaseState`
  - no key check for `G`, `R` and arrow keys: done in `BaseState` anyway
  - `halfWidth` and `halfHeight` are now filled on state's `create`: otherwise stay at `0`

Changes are minor, not feeling any platform-specific quirks in effect here. Tested out on Linux/C++ target and Flash, works fine.

My first pull request **ever**. Might have screwed up somewhere =)
