### PR TITLE
Fix if condition in FlxSnake, to get the real body segment count shown

### DIFF
--- a/Arcade Classics/FlxSnake/source/PlayState.hx
+++ b/Arcade Classics/FlxSnake/source/PlayState.hx
@@ -210,7 +210,7 @@ class PlayState extends FlxState
 	{	
 		_headPositions.unshift(FlxPoint.get(_snakeHead.x, _snakeHead.y));
 		
-		if (_headPositions.length >= _snakeBody.members.length)
+		if (_headPositions.length > _snakeBody.members.length)
 		{
 			_headPositions.pop();
 		}


### PR DESCRIPTION
I fixed the if condition in FlxSnake that stops you from getting the real body segment size shown.
