### PR TITLE
Fixing FlxFSM Demo bug when you get powerup while still in Jump state

### DIFF
--- a/Flixel Features/FlxFSM/FlxFSM.hxproj
+++ b/Flixel Features/FlxFSM/FlxFSM.hxproj
@@ -24,12 +24,12 @@
   </classpaths>
   <!-- Build options -->
   <build>
-    <option directives="flixel=3.3.8&#xA;openfl=3.0.8&#xA;lime=2.4.2&#xA;flixel-addons=1.1.0&#xA;openfl-next&#xA;tools=2.4.2&#xA;no-compilation&#xA;openfl-flash&#xA;web" />
+    <option directives="flixel=3.3.8&#xA;openfl=3.0.8&#xA;lime=2.4.2&#xA;flixel-addons=1.1.0&#xA;openfl-next&#xA;tools=2.4.2&#xA;FLX_NO_DEBUG&#xA;no-compilation&#xA;NAPE_RELEASE_BUILD&#xA;openfl-flash&#xA;web" />
     <option flashStrict="False" />
     <option noInlineOnDebug="False" />
     <option mainClass="ApplicationMain" />
     <option enabledebug="False" />
-    <option additional="--macro flixel.system.macros.FlxDefines.run()&#xA;-swf-version 11.8&#xA;-debug " />
+    <option additional="--macro flixel.system.macros.FlxDefines.run()&#xA;-swf-version 11.8" />
   </build>
   <!-- haxelib libraries -->
   <haxelib>

--- a/Flixel Features/FlxFSM/source/PlayState.hx
+++ b/Flixel Features/FlxFSM/source/PlayState.hx
@@ -65,6 +65,7 @@ class PlayState extends FlxState
 	
 	override public function update(elapsed:Float):Void
 	{
+		
 		super.update(elapsed);
 		
 		FlxG.collide(_map, _slime);
@@ -74,9 +75,11 @@ class PlayState extends FlxState
 	}
 	
 	private function getPowerup(S:Slime, P:FlxSprite):Void
-	{
-		
+	{		
+		S.fsm.transitions.start(Slime.Idle);
 		S.fsm.transitions.replace(Slime.Jump, Slime.SuperJump);
+		
 		P.kill();
+		
 	}
 }


### PR DESCRIPTION
When using `fsm.transitions.replace...` to replace a state, if the fsm is in the state being replaced, it may not 'exit' that state properly.