### PR TITLE
Minor modifications to the FlxCamera example to make the code clearer.

### DIFF
--- a/Features/FlxCamera/source/HUD.hx
+++ b/Features/FlxCamera/source/HUD.hx
@@ -15,18 +15,22 @@ class HUD extends FlxGroup
 	private var txtLead:FlxText;
 	private var txtZoom:FlxText;
 	public var background:FlxSprite;
+	public var width:Int;
+	public var height:Int;
 
 	public function new() 
 	{
 		super();
 		
-		background = new FlxSprite(10000 -50, -175);
-		background.makeGraphic(300, 360, FlxColor.BLACK);
+		width = 200;
+		height = 180;
+		
+		background = new FlxSprite(10000, 0);
+		background.makeGraphic(width, height, FlxColor.BLACK);
 		add(background);
 		
 		var x:Int = 10006;
 		var startY:Int = 10;
-		var width:Int = 300;
 		
 		add(new FlxText(x, startY, width, "[W,A,S,D] or arrows to control the orb.")); 
 		

--- a/Features/FlxCamera/source/PlayState.hx
+++ b/Features/FlxCamera/source/PlayState.hx
@@ -145,12 +145,12 @@ class PlayState extends FlxState
 		FlxG.camera.follow(orb, LOCKON, 1);
 		
 		#if TRUE_ZOOM_OUT
-		hudCam = new FlxCamera(440 + 50, 0 + 45, 200, 180); // +50 + 45 For 1/2 zoom out.
+		hudCam = new FlxCamera(440 + 50, 0 + 45, hud.width, hud.height); // +50 + 45 For 1/2 zoom out.
 		#else
-		hudCam = new FlxCamera(440, 0, 200, 180);
+		hudCam = new FlxCamera(440, 0, hud.width, hud.height);
 		#end
 		hudCam.zoom = 1; // For 1/2 zoom out.
-		hudCam.follow(hud.background);
+		hudCam.follow(hud.background, FlxCameraFollowStyle.NO_DEAD_ZONE);
 		hudCam.alpha = .5;
 		FlxG.cameras.add(hudCam);
 	}


### PR DESCRIPTION
Some confusion arose about magic numbers in the FlxCamera demo, as seen [here](https://groups.google.com/d/msg/haxeflixel/BMohE0iWngw/PierUY83DQAJ). I had the same problem when I first explored the demo, so I assume there are probably others who are / were troubled by it as well.

To combat that, I made minor modifications to the `HUD` and `PlayState` classes of this demo.

I explicitly specified the `width` and `height` properties of the HUD. These values are referenced when creating the HUD camera, HUD background graphic, and when positioning HUD text.

I also specified the `FlxCameraFollowStyle` of the HUD camera as `NO_DEAD_ZONE`. I feel this is more suitable because the HUD is a static entity, and it centres the camera neatly on the target it is tasked with following.