### PR TITLE
Fix MenuState.hx Comment Typo

### DIFF
--- a/Tutorials/TurnBasedRPG/source/MenuState.hx
+++ b/Tutorials/TurnBasedRPG/source/MenuState.hx
@@ -19,7 +19,7 @@ class MenuState extends FlxState
 	
 	override public function create():Void
 	{
-		if (FlxG.sound.music == null) // don't restart the music if it's alredy playing
+		if (FlxG.sound.music == null) // don't restart the music if it's already playing
 		{
 			#if flash
 			FlxG.sound.playMusic(AssetPaths.HaxeFlixel_Tutorial_Game__mp3, 1, true);


### PR DESCRIPTION
Replaced the only comment typo; `alredy` should be `already` on line 22. All other spacing and spelling looks good.