### PR TITLE
TurnBasedRPG: fix highscore not being saved

### DIFF
--- a/Tutorials/TurnBasedRPG/source/GameOverState.hx
+++ b/Tutorials/TurnBasedRPG/source/GameOverState.hx
@@ -90,16 +90,14 @@ class GameOverState extends FlxState
 		var _save:FlxSave = new FlxSave();
 		if (_save.bind("flixel-tutorial"))
 		{
-			if (_save.data.hiscore != null)
+			if (_save.data.hiscore != null && _save.data.hiscore > _hi)
 			{
-				if (_save.data.hiscore > _hi)
-				{
-					_hi = _save.data.hiscore;
-				}
-				else
-				{
-					_save.data.hiscore = _hi;
-				}
+				_hi = _save.data.hiscore;
+			}
+			else
+			{
+				// data is less or there is no data; save current score
+				_save.data.hiscore = _hi;
 			}
 		}
 		_save.close();


### PR DESCRIPTION
### Description
This pull request corrects the issue where the Tutorial "TurnBasedRPG" is not properly saving high scores at the end of the game (Game Over screen).

### Steps to reproduce:
1. Play the game and collect a high number of coins (e.g. 10 coins). 
2. Die or kill the boss. You will see "Hi-Score: 10" on the Game Over screen.
3. Go back to the main menu and play again. Collect a low number of coins (e.g. 5 coins). 
4. Die or kill the boss. You will see "Hi-Score: 5" on the Game Over screen.

**Expected result:** The game should display "Hi-Score: 10" on the Game Over Screen.
**Actual result:** The game displays "Hi-Score: 5" on the Game Over Screen.

### Analysis:
This is due to a logical error in the `checkHiScore()` function. Below, we can see that if the high score does not yet exist on the save data object, it never gets created.

```haxe
	var _save:FlxSave = new FlxSave();
	if (_save.bind("flixel-tutorial"))  // this check passes OK
	{
		if (_save.data.hiscore != null)  // no existing high score data; check fails
		{
			// this code is unreachable
			if (_save.data.hiscore > _hi)
			{
				_hi = _save.data.hiscore;
			}
			else
			{
				_save.data.hiscore = _hi;
			}
		}
		// NO ELSE CASE HERE. Save data is never created!
	}
	_save.close();
```

The simple solution is to create an else case containing `_save.data.hiscore = _hi;`. However, by the DRY principle, we can rework the if-else check to something shorter:

```haxe
	var _save:FlxSave = new FlxSave();
	if (_save.bind("flixel-tutorial"))
	{
		if (_save.data.hiscore != null && _save.data.hiscore > _hi)
		{
			_hi = _save.data.hiscore;
		}
		else
		{
			// data is less or there is no data; save current score
			_save.data.hiscore = _hi;
		}
	}
	_save.close();
```

This code has been tested with neko to work as expected.