### PR TITLE
Fix DeadZoneMode dropdown to not go off screen

### DIFF
--- a/Input/GamepadTest/source/PlayState.hx
+++ b/Input/GamepadTest/source/PlayState.hx
@@ -95,6 +95,7 @@ class PlayState extends FlxState
 				if (gamepad != null)
 					gamepad.deadZoneMode = FlxGamepadDeadZoneMode.createByName(mode);
 			}, new FlxUIDropDownHeader(130)));
+		deadZoneModeDropDown.dropDirection = Up;
 	}
 	
 	function createDisconnectedOverlay():Void


### PR DESCRIPTION
Sorry if I already created a pull request before. I just can't seem to find it in my github profile. If that's the case let me know and I wont make a pull request for this again.