### PR TITLE
default enable simpleRender on html

### DIFF
--- a/Effects/FlxTrailArea/source/BlurState.hx
+++ b/Effects/FlxTrailArea/source/BlurState.hx
@@ -19,6 +19,9 @@ class BlurState extends FlxState
 		// The first thing to do is setting up the FlxTrailArea
 		var trailArea = new FlxTrailArea(0, 0, FlxG.width - 200, FlxG.height);
 		trailArea.antialiasing = true;
+		#if html5
+		trailArea.simpleRender = true;
+		#end
 
 		// This just sets up an emitter at the bottom of the screen
 		var emitter = new FlxEmitter(0, FlxG.height + 20, 50);

--- a/Effects/FlxTrailArea/source/ParticleState.hx
+++ b/Effects/FlxTrailArea/source/ParticleState.hx
@@ -21,6 +21,9 @@ class ParticleState extends FlxState
 	{
 		// Sets up the FlxTrail area on the top left of the screen with an area over the whole black part of the screen
 		var trailArea = new FlxTrailArea(0, 0, FlxG.width - 200, FlxG.height);
+		#if html5
+		trailArea.simpleRender = true;
+		#end
 
 		// Sets up the emitter for the particle explosion
 		_emitter = new FlxEmitter(200, FlxG.height / 2, PARTICLE_AMOUNT);


### PR DESCRIPTION
These demos run like crap for me on Chrome for OSX with simpleRendering disabled and it doesn't look any worse when enabled