### PR TITLE
Save demo HTML5 fix

### DIFF
--- a/Features/Save/source/PlayState.hx
+++ b/Features/Save/source/PlayState.hx
@@ -157,12 +157,14 @@ class PlayState extends FlxState
 			// You can also do something like gameSave.data.randomBool = true;
 			// and if randomBool didn't exist before, then flash will create a boolean there.
 			// though it's best to make a new type() before setting it, so you know the correct type is kept
-			_gameSave.data.boxPositions = new Array();
+			var boxPositions = new Array();
 
 			for (box in _boxGroup)
 			{
-				_gameSave.data.boxPositions.push(FlxPoint.get(box.x, box.y));
+				boxPositions.push(FlxPoint.get(box.x, box.y));
 			}
+
+			_gameSave.data.boxPositions = boxPositions;
 
 			_topText.text = "Created a new save, and saved positions";
 			_topText.alpha = 1;


### PR DESCRIPTION
When attempting to save, it either throws `this._gameSave.data.boxPositions[a] is undefined` or `can't convert undefined to object`.

It doesn't properly set the array on the dynamic object (`_gameSave.data` / `_gameSave.data.boxPositions`). This just redoes a bit of the behaviour to set the array properly, by creating a temp one that DOES get properly pushed to with the box data.

I think the code comment above the modified lines of code should also be changed as well to reflect the new behavious