### PR TITLE
Remove mention of icon priorities.

### DIFF
--- a/Arcade/Breakout/Project.xml
+++ b/Arcade/Breakout/Project.xml
@@ -79,5 +79,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Arcade/Flappybalt/Project.xml
+++ b/Arcade/Flappybalt/Project.xml
@@ -80,7 +80,7 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 	
 	<icon path="assets/icon.svg"/>
 	

--- a/Arcade/Flixius/Project.xml
+++ b/Arcade/Flixius/Project.xml
@@ -82,5 +82,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Arcade/FlxInvaders/Project.xml
+++ b/Arcade/FlxInvaders/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Arcade/FlxLightPuzzle/Project.xml
+++ b/Arcade/FlxLightPuzzle/Project.xml
@@ -83,5 +83,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Arcade/FlxPongApi/Project.xml
+++ b/Arcade/FlxPongApi/Project.xml
@@ -79,7 +79,7 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 	<icon path="assets/HaxeFlixel_Addons.svg" />
 	
 	<assets path="assets/sounds">

--- a/Arcade/FlxSnake/Project.xml
+++ b/Arcade/FlxSnake/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Arcade/FlxTeroids/Project.xml
+++ b/Arcade/FlxTeroids/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Arcade/MinimalistTD/Project.xml
+++ b/Arcade/MinimalistTD/Project.xml
@@ -79,7 +79,7 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 	
 	<assets path="assets/sounds">
 		<sound path="build.mp3" id="build" />

--- a/Editors/FlxPexParser/Project.xml
+++ b/Editors/FlxPexParser/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Editors/FlxSpine/Project.xml
+++ b/Editors/FlxSpine/Project.xml
@@ -82,5 +82,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Editors/TexturePackerAtlas/Project.xml
+++ b/Editors/TexturePackerAtlas/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Editors/TiledEditor/Project.xml
+++ b/Editors/TiledEditor/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/BlendModeShaders/Project.xml
+++ b/Effects/BlendModeShaders/Project.xml
@@ -84,5 +84,5 @@
 
 	<!-- _________________________________ Custom _______________________________ -->
 
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/BlendModes/Project.xml
+++ b/Effects/BlendModes/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/DynamicShadows/Project.xml
+++ b/Effects/DynamicShadows/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/Filters/Project.xml
+++ b/Effects/Filters/Project.xml
@@ -89,5 +89,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/FloodFill/Project.xml
+++ b/Effects/FloodFill/Project.xml
@@ -80,5 +80,5 @@
 
 	<!-- _________________________________ Custom _______________________________ -->
 
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/FlxBloom/Project.xml
+++ b/Effects/FlxBloom/Project.xml
@@ -79,5 +79,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/FlxBlur/Project.xml
+++ b/Effects/FlxBlur/Project.xml
@@ -79,5 +79,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/FlxClothSprite/Project.xml
+++ b/Effects/FlxClothSprite/Project.xml
@@ -80,5 +80,5 @@
 
 	<!-- _________________________________ Custom _______________________________ -->
 
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/FlxEffectSprite/Project.xml
+++ b/Effects/FlxEffectSprite/Project.xml
@@ -80,5 +80,5 @@
 
 	<!-- _________________________________ Custom _______________________________ -->
 
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/FlxFloodFill/Project.xml
+++ b/Effects/FlxFloodFill/Project.xml
@@ -80,5 +80,5 @@
 
 	<!-- _________________________________ Custom _______________________________ -->
 
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/FlxSimplex/Project.xml
+++ b/Effects/FlxSimplex/Project.xml
@@ -79,5 +79,5 @@
 
 	<!-- _________________________________ Custom _______________________________ -->
 
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/FlxSkewedSprite/Project.xml
+++ b/Effects/FlxSkewedSprite/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/FlxSpriteFilters/project.xml
+++ b/Effects/FlxSpriteFilters/project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/FlxTrailArea/Project.xml
+++ b/Effects/FlxTrailArea/Project.xml
@@ -79,5 +79,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/FlxTween/Project.xml
+++ b/Effects/FlxTween/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/MosaicEffect/Project.xml
+++ b/Effects/MosaicEffect/Project.xml
@@ -85,5 +85,5 @@
 
 	<!-- _________________________________ Custom _______________________________ -->
 
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/Parallax/Project.xml
+++ b/Effects/Parallax/Project.xml
@@ -82,5 +82,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/PostProcess/Project.xml
+++ b/Effects/PostProcess/Project.xml
@@ -81,5 +81,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Effects/Transitions/Project.xml
+++ b/Effects/Transitions/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/CollisionAndGrouping/Project.xml
+++ b/Features/CollisionAndGrouping/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/FlxCamera/project.xml
+++ b/Features/FlxCamera/project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/FlxFSM/Project.xml
+++ b/Features/FlxFSM/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/FlxNape/project.xml
+++ b/Features/FlxNape/project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/FlxNapeTerrain/Project.xml
+++ b/Features/FlxNapeTerrain/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/FlxScene/Project.xml
+++ b/Features/FlxScene/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/FlxSound/Project.xml
+++ b/Features/FlxSound/Project.xml
@@ -82,5 +82,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/HeatmapPathfinding/Project.xml
+++ b/Features/HeatmapPathfinding/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/Particles/Project.xml
+++ b/Features/Particles/Project.xml
@@ -79,5 +79,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/Pathfinding/Project.xml
+++ b/Features/Pathfinding/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/Replay/Project.xml
+++ b/Features/Replay/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/Save/Project.xml
+++ b/Features/Save/Project.xml
@@ -79,5 +79,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/ScaleModes/Project.xml
+++ b/Features/ScaleModes/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/SetTileProperties/Project.xml
+++ b/Features/SetTileProperties/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/SplitScreen/Project.xml
+++ b/Features/SplitScreen/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Features/Tilemap/Project.xml
+++ b/Features/Tilemap/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Input/FlxAccelerometer/Project.xml
+++ b/Input/FlxAccelerometer/Project.xml
@@ -79,5 +79,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Input/FlxAction/Project.xml
+++ b/Input/FlxAction/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Input/FlxMouseEventManager/Project.xml
+++ b/Input/FlxMouseEventManager/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Input/GamepadTest/Project.xml
+++ b/Input/GamepadTest/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Input/GridMovement/Project.xml
+++ b/Input/GridMovement/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Input/Multitouch/Project.xml
+++ b/Input/Multitouch/Project.xml
@@ -79,5 +79,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Other/BSPMapGen/Project.xml
+++ b/Other/BSPMapGen/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Other/FlxAsyncLoop/Project.xml
+++ b/Other/FlxAsyncLoop/Project.xml
@@ -79,5 +79,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Other/FlxAtlas/Project.xml
+++ b/Other/FlxAtlas/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Other/FlxCollisions/Project.xml
+++ b/Other/FlxCollisions/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Other/FrameCollections/Project.xml
+++ b/Other/FrameCollections/Project.xml
@@ -77,5 +77,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Performance/FlxBunnyMark/Project.xml
+++ b/Performance/FlxBunnyMark/Project.xml
@@ -84,5 +84,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Performance/FlxRandom/Project.xml
+++ b/Performance/FlxRandom/Project.xml
@@ -77,6 +77,6 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 	<haxeflag name="-D" value="swf-script-timeout=65" />
 </project>

--- a/Performance/NeonVector/Project.xml
+++ b/Performance/NeonVector/Project.xml
@@ -80,7 +80,7 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 	<assets path="assets/images" rename="images" />
 
 	<section if="flash || html5">

--- a/Performance/PixelPerfectCollision/Project.xml
+++ b/Performance/PixelPerfectCollision/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Platformers/EZPlatformer/Project.xml
+++ b/Platformers/EZPlatformer/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Platformers/FlipRotationAnimationTiles/Project.xml
+++ b/Platformers/FlipRotationAnimationTiles/Project.xml
@@ -80,7 +80,7 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 	<assets path="assets/images" rename ="images" />
 	<assets path="assets/maps" rename ="maps" />
 </project>

--- a/Platformers/FlxCaveGenerator/Project.xml
+++ b/Platformers/FlxCaveGenerator/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Platformers/FlxTilemapExt/Project.xml
+++ b/Platformers/FlxTilemapExt/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Platformers/Mode/Project.xml
+++ b/Platformers/Mode/Project.xml
@@ -79,7 +79,7 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 	
 	<assets path="assets" exclude="*.ogg|*.mp3" />
 	<assets path="assets" include="*.mp3" if="web || air" />

--- a/Platformers/ProjectJumper/Project.xml
+++ b/Platformers/ProjectJumper/Project.xml
@@ -81,5 +81,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Platformers/Revenge/Project.xml
+++ b/Platformers/Revenge/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/Tutorials/TurnBasedRPG/Project.xml
+++ b/Tutorials/TurnBasedRPG/Project.xml
@@ -81,5 +81,5 @@
 
 	<!-- _________________________________ Custom _______________________________ -->
 
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/UserInterface/Cursor/Project.xml
+++ b/UserInterface/Cursor/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/UserInterface/FileBrowse/Project.xml
+++ b/UserInterface/FileBrowse/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/UserInterface/FlxBitmapText/Project.xml
+++ b/UserInterface/FlxBitmapText/Project.xml
@@ -74,5 +74,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/UserInterface/FlxTextFormat/Project.xml
+++ b/UserInterface/FlxTextFormat/Project.xml
@@ -79,5 +79,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/UserInterface/FlxTypeText/Project.xml
+++ b/UserInterface/FlxTypeText/Project.xml
@@ -81,5 +81,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/UserInterface/RPGInterface/Project.xml
+++ b/UserInterface/RPGInterface/Project.xml
@@ -82,5 +82,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>

--- a/UserInterface/Tooltips/Project.xml
+++ b/UserInterface/Tooltips/Project.xml
@@ -80,5 +80,5 @@
 	
 	<!-- _________________________________ Custom _______________________________ -->
 	
-	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+	<!-- Place custom nodes like icons here -->
 </project>


### PR DESCRIPTION
Once https://github.com/HaxeFlixel/flixel/commit/748c5d8b0b618c2cf9b08753c4b915629e342ab0 is merged, the user's icons will always override HaxeFlixel's, regardless of order. There will be no more need to warn them about it.