### PR TITLE
MinimalistTD: fix bugs: overlapping buttons and recycled sprites

### DIFF
--- a/Arcade/MinimalistTD/source/Bullet.hx
+++ b/Arcade/MinimalistTD/source/Bullet.hx
@@ -56,9 +56,14 @@ class Bullet extends FlxSprite
 
 		// Move toward the target that was assigned in init().
 
-		if (_target.alive)
+		if (target != null && _target.alive)
 		{
 			FlxVelocity.moveTowardsObject(this, _target, 200);
+		}
+		else
+		{
+			// Target may be recycled, so we no longer want to point to it.
+			_target = null;
 		}
 
 		super.update(elapsed);

--- a/Arcade/MinimalistTD/source/Bullet.hx
+++ b/Arcade/MinimalistTD/source/Bullet.hx
@@ -56,7 +56,7 @@ class Bullet extends FlxSprite
 
 		// Move toward the target that was assigned in init().
 
-		if (target != null && _target.alive)
+		if (_target != null && _target.alive)
 		{
 			FlxVelocity.moveTowardsObject(this, _target, 200);
 		}

--- a/Arcade/MinimalistTD/source/PlayState.hx
+++ b/Arcade/MinimalistTD/source/PlayState.hx
@@ -1,19 +1,19 @@
 package;
 
-import flash.display.Sprite;
+import Reg.TILE_SIZE;
 import flash.display.BlendMode;
+import flash.display.Sprite;
 import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.FlxState;
 import flixel.group.FlxGroup;
-import flixel.text.FlxText;
-import flixel.tile.FlxTilemap;
-import flixel.tweens.FlxTween;
-import flixel.tweens.FlxEase;
-import flixel.util.FlxColor;
 import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
-import Reg.TILE_SIZE;
+import flixel.text.FlxText;
+import flixel.tile.FlxTilemap;
+import flixel.tweens.FlxEase;
+import flixel.tweens.FlxTween;
+import flixel.util.FlxColor;
 
 enum MenuType
 {
@@ -536,6 +536,10 @@ class PlayState extends FlxState
 	 */
 	function buildTowerCallback(Skip:Bool = false):Void
 	{
+		if (!_towerButton.visible)
+		{
+			return;
+		}
 		if (towerPrice > money)
 			return;
 


### PR DESCRIPTION
Range upgrade button also activates build tower botton.
Bullets re-acquire recycled enemy sprite once its resurrected.