### PR TITLE
Prevent soft-locking in RPGInterface demo (Fixes #267)

### DIFF
--- a/UserInterface/RPGInterface/assets/xml/state_default.xml
+++ b/UserInterface/RPGInterface/assets/xml/state_default.xml
@@ -52,10 +52,10 @@
 			</radio_group>
 		</group>
 		<group id="tab_2">
-			<checkbox x="10" y="10"label="$MENU_THING_1">
+			<checkbox x="10" y="10" label="$MENU_THING_1">
 				<param type="string" value="thing 1"/>
 			</checkbox>	
-			<checkbox x="10" y="40"label="$MENU_THING_2">
+			<checkbox x="10" y="40" label="$MENU_THING_2">
 				<param type="string" value="thing 2"/>
 			</checkbox>
 		</group>

--- a/UserInterface/RPGInterface/source/Popup_Default.hx
+++ b/UserInterface/RPGInterface/source/Popup_Default.hx
@@ -1,0 +1,43 @@
+import flixel.addons.ui.FlxUI;
+import flixel.addons.ui.interfaces.IFlxUIState;
+import flixel.addons.ui.FlxUITypedButton;
+import flixel.addons.ui.interfaces.IFlxUIWidget;
+import flixel.addons.ui.FlxUIPopup;
+
+class Popup_Default extends FlxUIPopup
+{
+	override function getEvent(id:String, sender:IFlxUIWidget, data:Dynamic, ?eventParams:Array<Dynamic>)
+	{
+		if (eventParams == null)
+		{
+			if (params != null)
+			{
+				eventParams = [];
+			}
+		}
+		if (params != null)
+		{
+			eventParams = eventParams.concat(params);
+		}
+
+		switch (id)
+		{
+			case FlxUITypedButton.CLICK_EVENT:
+				if (eventParams != null)
+				{
+					var buttonAmount:Int = Std.int(eventParams[0]); // 0 is Yes, 1 is No and 2 is Cancel
+					if ((_parentState is IFlxUIState))
+					{
+						// This fixes a bug where the event was being sent to this popup rather than the state that created it
+						castParent().getEvent(FlxUIPopup.CLICK_EVENT, this, buttonAmount, eventParams);
+					}
+					else
+					{
+						// This is a generic fallback in case something goes wrong
+						FlxUI.event(FlxUIPopup.CLICK_EVENT, this, buttonAmount, eventParams);
+					}
+					close();
+				}
+		}
+	}
+}

--- a/UserInterface/RPGInterface/source/State_DefaultTest.hx
+++ b/UserInterface/RPGInterface/source/State_DefaultTest.hx
@@ -1,3 +1,7 @@
+import flixel.addons.ui.FlxUI;
+import flixel.addons.ui.interfaces.IFlxUIState;
+import flixel.addons.ui.FlxUITypedButton;
+import flixel.addons.ui.interfaces.IFlxUIWidget;
 import flixel.addons.ui.FlxUIPopup;
 import flixel.FlxG;
 import flixel.addons.ui.FlxUIState;
@@ -29,7 +33,7 @@ class State_DefaultTest extends FlxUIState
 					{
 						case "back": FlxG.switchState(new State_Title());
 						case "popup":
-							var popup:FlxUIPopup = new FlxUIPopup(); // create the popup
+							var popup:FlxUIPopup = new PopupFix(); // create the popup
 							popup.quickSetup // set it up
 							(Main.tongue.get("$POPUP_DEMO_2_TITLE", "ui"), // title text
 								Main.tongue.get("$POPUP_DEMO_2_BODY", "ui"), // body text
@@ -52,6 +56,47 @@ class State_DefaultTest extends FlxUIState
 						case 2: FlxG.log.add("Cancel was clicked");
 					}
 			}
+		}
+	}
+}
+
+/**
+ * An extension to `FlxUIPopup` that fixes a bug in `getEvent` where the event was not being broadcast correctly to the parent widget
+ */
+class PopupFix extends FlxUIPopup
+{
+	override function getEvent(id:String, sender:IFlxUIWidget, data:Dynamic, ?eventParams:Array<Dynamic>)
+	{
+		if (eventParams == null)
+		{
+			if (params != null)
+			{
+				eventParams = [];
+			}
+		}
+		if (params != null)
+		{
+			eventParams = eventParams.concat(params);
+		}
+
+		switch (id)
+		{
+			case FlxUITypedButton.CLICK_EVENT:
+				if (eventParams != null)
+				{
+					var buttonAmount:Int = Std.int(eventParams[0]); // 0 is Yes, 1 is No and 2 is Cancel
+					if ((_parentState is IFlxUIState))
+					{
+						// This fixes a bug where the event was being sent to this popup rather than the state that created it
+						castParent().getEvent(FlxUIPopup.CLICK_EVENT, this, buttonAmount, eventParams);
+					}
+					else
+					{
+						// This is a generic fallback in case something goes wrong
+						FlxUI.event(FlxUIPopup.CLICK_EVENT, this, buttonAmount, eventParams);
+					}
+					close();
+				}
 		}
 	}
 }

--- a/UserInterface/RPGInterface/source/State_DefaultTest.hx
+++ b/UserInterface/RPGInterface/source/State_DefaultTest.hx
@@ -1,7 +1,3 @@
-import flixel.addons.ui.FlxUI;
-import flixel.addons.ui.interfaces.IFlxUIState;
-import flixel.addons.ui.FlxUITypedButton;
-import flixel.addons.ui.interfaces.IFlxUIWidget;
 import flixel.addons.ui.FlxUIPopup;
 import flixel.FlxG;
 import flixel.addons.ui.FlxUIState;
@@ -33,7 +29,7 @@ class State_DefaultTest extends FlxUIState
 					{
 						case "back": FlxG.switchState(new State_Title());
 						case "popup":
-							var popup:FlxUIPopup = new PopupFix(); // create the popup
+							var popup:FlxUIPopup = new Popup_Default(); // create the popup
 							popup.quickSetup // set it up
 							(Main.tongue.get("$POPUP_DEMO_2_TITLE", "ui"), // title text
 								Main.tongue.get("$POPUP_DEMO_2_BODY", "ui"), // body text
@@ -56,47 +52,6 @@ class State_DefaultTest extends FlxUIState
 						case 2: FlxG.log.add("Cancel was clicked");
 					}
 			}
-		}
-	}
-}
-
-/**
- * An extension to `FlxUIPopup` that fixes a bug in `getEvent` where the event was not being broadcast correctly to the parent widget
- */
-class PopupFix extends FlxUIPopup
-{
-	override function getEvent(id:String, sender:IFlxUIWidget, data:Dynamic, ?eventParams:Array<Dynamic>)
-	{
-		if (eventParams == null)
-		{
-			if (params != null)
-			{
-				eventParams = [];
-			}
-		}
-		if (params != null)
-		{
-			eventParams = eventParams.concat(params);
-		}
-
-		switch (id)
-		{
-			case FlxUITypedButton.CLICK_EVENT:
-				if (eventParams != null)
-				{
-					var buttonAmount:Int = Std.int(eventParams[0]); // 0 is Yes, 1 is No and 2 is Cancel
-					if ((_parentState is IFlxUIState))
-					{
-						// This fixes a bug where the event was being sent to this popup rather than the state that created it
-						castParent().getEvent(FlxUIPopup.CLICK_EVENT, this, buttonAmount, eventParams);
-					}
-					else
-					{
-						// This is a generic fallback in case something goes wrong
-						FlxUI.event(FlxUIPopup.CLICK_EVENT, this, buttonAmount, eventParams);
-					}
-					close();
-				}
 		}
 	}
 }


### PR DESCRIPTION
Fix for #267. For some reason, `FlxUIPopup` does not propagate `CLICK_EVENT` correctly to the parent state.