### PR TITLE
remove neko from github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         haxe-version: ["4.2.5", "4.3.3", latest]
-        target: [html5, hl, neko, flash, cpp]
+        target: [html5, hl, flash, cpp]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The last update to neko was 5 years ago in 2019, and the release before that was 7 years ago! Neko has been superseded by Hashlink, so I think we can put focus (and Github actions compile time!) into that and remove neko entirely, since I don't think we are going to focus on any Neko specific fixes if/when they come up anyways