### PR TITLE
put mPos back into the pool

### DIFF
--- a/Other/FlxGameOfLife/source/PlayState.hx
+++ b/Other/FlxGameOfLife/source/PlayState.hx
@@ -455,6 +455,7 @@ class PlayState extends FlxState
 			mouseMode = NONE;
 			updateMouseCursor(false);
 		}
+		mPos.put();
 	}
 
 	/**


### PR DESCRIPTION
simple change, preventing memory leaks