### PR TITLE
fix rotation on flxfilterframes demo

### DIFF
--- a/Effects/FlxSpriteFilters/source/PlayState.hx
+++ b/Effects/FlxSpriteFilters/source/PlayState.hx
@@ -1,6 +1,5 @@
 package;
 
-import openfl.filters.BitmapFilterQuality;
 import flash.filters.BitmapFilter;
 import flash.filters.BlurFilter;
 import flash.filters.DropShadowFilter;

--- a/Effects/FlxSpriteFilters/source/PlayState.hx
+++ b/Effects/FlxSpriteFilters/source/PlayState.hx
@@ -205,6 +205,7 @@ class PlayState extends FlxState
 
 	function updateFilter(spr:FlxSprite, sprFilter:FlxFilterFrames)
 	{
+		// Reset the offset, it will ballon with each apply call
 		spr.offset.set();
 		sprFilter.applyToSprite(spr, false, true);
 	}

--- a/Effects/FlxSpriteFilters/source/PlayState.hx
+++ b/Effects/FlxSpriteFilters/source/PlayState.hx
@@ -1,5 +1,6 @@
 package;
 
+import openfl.filters.BitmapFilterQuality;
 import flash.filters.BitmapFilter;
 import flash.filters.BlurFilter;
 import flash.filters.DropShadowFilter;
@@ -163,22 +164,27 @@ class PlayState extends FlxState
 		}
 		if (isAnimSpr2)
 		{
+			spr2.angle += 45 * elapsed;
 			updateFilter(spr2, spr2Filter);
 		}
 		if (isAnimSpr3)
 		{
+			spr3.angle += 45 * elapsed;
 			updateFilter(spr3, spr3Filter);
 		}
 		if (isAnimSpr4)
 		{
+			spr4.angle += 45 * elapsed;
 			updateDropShadowFilter(elapsed);
 		}
 		if (isAnimSpr5)
 		{
+			spr5.angle += 45 * elapsed;
 			updateFilter(spr5, spr5Filter);
 		}
 		if (isAnimSpr6)
 		{
+			spr6.angle += 45 * elapsed;
 			updateDisplaceFilter();
 		}
 	}
@@ -200,6 +206,7 @@ class PlayState extends FlxState
 
 	function updateFilter(spr:FlxSprite, sprFilter:FlxFilterFrames)
 	{
+		spr.offset.set();
 		sprFilter.applyToSprite(spr, false, true);
 	}
 }


### PR DESCRIPTION
I believe in `FlxFilterFrames.applyToSprite()` function, it adds an offset (from this flixel merge/pr https://github.com/HaxeFlixel/flixel/pull/2176)

here we simply just reset the offset to the sprite, so it doesn't adjust the offset incorrectly and constantly increment it