### PR TITLE
fix bug from tilemapExt not placing tiles

### DIFF
--- a/Platformers/FlxTilemapExt/source/PlayState.hx
+++ b/Platformers/FlxTilemapExt/source/PlayState.hx
@@ -83,15 +83,15 @@ class PlayState extends FlxState
 		_hud.add(_levelText);
 	}
 
-	function fallInClouds(Tile:FlxObject, Object:FlxObject):Void
+	function fallInClouds(tile:FlxObject, object:FlxObject):Void
 	{
 		if (FlxG.keys.anyPressed([DOWN, S]))
 		{
-			Tile.allowCollisions = NONE;
+			tile.allowCollisions = NONE;
 		}
-		else if (Object.y >= Tile.y)
+		else
 		{
-			Tile.allowCollisions = CEILING;
+			tile.allowCollisions = CEILING;
 		}
 	}
 


### PR DESCRIPTION
This line is never false with flixel-addons v 3.2.3 (i.e. latest), but with the upcoming version this will always be false
```hx
if (Object.y >= Tile.y)
```

I believe this is a typo and should be `<=` but it didn't work as expected because FlxTilemapExt tiles are not placed at the site of the overlap checked, like they are in FlxTilemap. when that didn't work they assumed they made a typo and flipped it to `>=` because "that fixed it"