### PR TITLE
Fix game filters not applying

### DIFF
--- a/Effects/Filters/source/PlayState.hx
+++ b/Effects/Filters/source/PlayState.hx
@@ -131,6 +131,8 @@ class PlayState extends FlxState
 		checkbox.callback = function()
 		{
 			FlxG.camera.filtersEnabled = !checkbox.checked;
+
+			FlxG.game.setFilters(filters);
 			FlxG.game.filtersEnabled = checkbox.checked;
 		}
 	}

--- a/Effects/Filters/source/PlayState.hx
+++ b/Effects/Filters/source/PlayState.hx
@@ -110,7 +110,7 @@ class PlayState extends FlxState
 		add(backdrop);
 		
 		FlxG.camera.filters = filters;
-		FlxG.game.filters = filters;
+		FlxG.game.setFilters(filters);
 		
 		FlxG.game.filtersEnabled = false;
 		
@@ -131,8 +131,6 @@ class PlayState extends FlxState
 		checkbox.callback = function()
 		{
 			FlxG.camera.filtersEnabled = !checkbox.checked;
-
-			FlxG.game.setFilters(filters);
 			FlxG.game.filtersEnabled = checkbox.checked;
 		}
 	}


### PR DESCRIPTION
FlxGame filters need to be set via the `setFilters()` function otherwise they'll get [overwritten in update](https://github.com/HaxeFlixel/flixel/blob/ed5300078914bf12705bd04e51b052d399bbefaa/flixel/FlxGame.hx#L772)

