### PR TITLE
fix: Flappybalt: bounce panels resetting thier sprites to default on `resetState()`

### DIFF
--- a/Arcade/Flappybalt/source/PlayState.hx
+++ b/Arcade/Flappybalt/source/PlayState.hx
@@ -69,17 +69,20 @@ class PlayState extends FlxState
 		if (Reg.highScore > 0)
 			_highScore.text = Std.string(Reg.highScore);
 
-		// The left bounce panel. Drawn via code in Reg to fit screen height.
+		// The bounce panel. Drawn via code in Reg to fit screen height.
+		final bounceImage = Reg.createBounceImage(FlxG.height - 34);
 
+		// The left bounce panel.
+		
 		_bounceLeft = new FlxSprite(1, 17);
-		_bounceLeft.loadGraphic(Reg.getBounceImage(FlxG.height - 34), true, 4, FlxG.height - 34);
+		_bounceLeft.loadGraphic(bounceImage, true, 4, FlxG.height - 34);
 		_bounceLeft.animation.add("flash", [1, 0], 8, false);
 		add(_bounceLeft);
 
 		// The right bounce panel.
 
 		_bounceRight = new FlxSprite(FlxG.width - 5, 17);
-		_bounceRight.loadGraphic(Reg.getBounceImage(FlxG.height - 34), true, 4, FlxG.height - 34);
+		_bounceRight.loadGraphic(bounceImage, true, 4, FlxG.height - 34);
 		_bounceRight.animation.add("flash", [1, 0], 8, false);
 		add(_bounceRight);
 

--- a/Arcade/Flappybalt/source/Reg.hx
+++ b/Arcade/Flappybalt/source/Reg.hx
@@ -37,40 +37,36 @@ class Reg
 	 * Draws the bounce panels. Useful for mobile devices with weird resolutions.
 	 *
 	 * @param	Height	The height of the panel to draw.
-	 * @return	A BitmapData object representing the paddle. Cached for the second paddle to save time.
+	 * @return	A BitmapData object representing the paddle.
 	 */
-	static public function getBounceImage(Height:Int):BitmapData
+	static public function createBounceImage(Height:Int):BitmapData
 	{
-		if (_bitmapData != null)
-			return _bitmapData;
+		var bitmapData:BitmapData = new BitmapData(8, Height, false, GREY_MED);
+		var rect:Rectangle;
 
-		_bitmapData = new BitmapData(8, Height, false, GREY_MED);
+		rect = new Rectangle(4, 0, 4, Height);
+		bitmapData.fillRect(rect, GREY_LIGHT);
+		rect = new Rectangle(0, 1, 1, Height - 2);
+		bitmapData.fillRect(rect, GREY_DARK);
+		rect.x = 3;
+		bitmapData.fillRect(rect, GREY_DARK);
+		rect = new Rectangle(1, 0, 2, 1);
+		bitmapData.fillRect(rect, GREY_DARK);
+		rect.y = Height - 1;
+		bitmapData.fillRect(rect, GREY_DARK);
+		rect = new Rectangle(4, 1, 1, Height - 2);
+		bitmapData.fillRect(rect, WHITE);
+		rect.x = 7;
+		bitmapData.fillRect(rect, WHITE);
+		rect = new Rectangle(5, 0, 2, 1);
+		bitmapData.fillRect(rect, WHITE);
+		rect.y = Height - 1;
+		bitmapData.fillRect(rect, WHITE);
 
-		_rect = new Rectangle(4, 0, 4, Height);
-		_bitmapData.fillRect(_rect, GREY_LIGHT);
-		_rect = new Rectangle(0, 1, 1, Height - 2);
-		_bitmapData.fillRect(_rect, GREY_DARK);
-		_rect.x = 3;
-		_bitmapData.fillRect(_rect, GREY_DARK);
-		_rect = new Rectangle(1, 0, 2, 1);
-		_bitmapData.fillRect(_rect, GREY_DARK);
-		_rect.y = Height - 1;
-		_bitmapData.fillRect(_rect, GREY_DARK);
-		_rect = new Rectangle(4, 1, 1, Height - 2);
-		_bitmapData.fillRect(_rect, WHITE);
-		_rect.x = 7;
-		_bitmapData.fillRect(_rect, WHITE);
-		_rect = new Rectangle(5, 0, 2, 1);
-		_bitmapData.fillRect(_rect, WHITE);
-		_rect.y = Height - 1;
-		_bitmapData.fillRect(_rect, WHITE);
-
-		return _bitmapData;
+		return bitmapData;
 	}
 
 	// This is all stuff used for drawing the paddles.
-	static var _bitmapData:BitmapData;
-	static var _rect:Rectangle;
 
 	inline static var WHITE:Int = 0xffFFFFFF;
 	inline static var GREY_LIGHT:Int = 0xffB0B0BF;


### PR DESCRIPTION
fixes #366 

See my lil comment there on null stuff